### PR TITLE
Optionally include the team in the secret ARN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,22 @@
-resource "aws_iam_policy" "secrets_policy" {                                    
-    name        = "${var.environment}-${var.component}-secrets"      
-    description = "Secrets access"                                              
-    policy      = "${data.aws_iam_policy_document.secrets_access.json}"         
+resource "aws_iam_policy" "secrets_policy" {
+  name        = "${var.environment}-${var.component}-secrets"
+  description = "Secrets access"
+  policy      = "${data.aws_iam_policy_document.secrets_access.json}"
 }
 
-data "aws_iam_policy_document" "secrets_access" {                               
-  statement {                                                                   
-    actions = [                                                                 
-      "secretsmanager:GetSecretValue",                                          
-    ]                                                                           
-                                                                                
-    resources = [                                                               
-      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${var.component}/${var.environment}/*",
-    ]                                                                           
-  }                                                                             
+locals {
+  arn_base         = "arn:aws:secretsmanager:${data.aws_region.current.name}"
+  secret_namespace = "${var.team == "" ? "" : "${var.team}/"}${var.component}/${var.environment}/*"
+}
+
+data "aws_iam_policy_document" "secrets_access" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      "${local.arn_base}:${data.aws_caller_identity.current.account_id}:secret:${local.secret_namespace}",
+    ]
+  }
 }

--- a/tf_test.go
+++ b/tf_test.go
@@ -22,6 +22,7 @@ func WriteDummyProviderConfig() {
 variable "sts_endpoint" {}
 
 provider "aws" {
+  version                     = "2.4"
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_get_ec2_platforms      = true

--- a/tf_test.go
+++ b/tf_test.go
@@ -63,7 +63,7 @@ func ReadTerraformPlan(planFilePath string) *terraform.Plan {
 
 func Setup(tfargs ...string) *TestingPlan {
 	WriteDummyProviderConfig()
-    RunTerraformCommand("terraform", "init")
+    RunTerraformCommand("terraform", "init", "-upgrade=true")
     basePlanArgs := []string{"terraform", "plan", "-out", PLAN_FILE}
     tfargs = append(basePlanArgs, tfargs...)
 	RunTerraformCommand(

--- a/variable.tf
+++ b/variable.tf
@@ -8,6 +8,12 @@ variable "environment" {
   description = "The environment which these secrets are for"
 }
 
+variable "team" {
+  type        = "string"
+  description = "The team who owns this secret"
+  default     = ""
+}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}


### PR DESCRIPTION
We'd like to namespace secrets under the team to better allow us to restrict access to them whilst staying within IAM policy size limits.